### PR TITLE
Fix v2 schema validation, add remote registry e2e

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titrate/plug",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "bin": {
     "plug": "dist/index.js"

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -118,7 +118,7 @@ function registerInstall(program: Command): void {
           try {
             const data = await downloadFile(formatEntry.url);
 
-            if (!verifyChecksum(data, formatEntry.sha256)) {
+            if (formatEntry.sha256 && !verifyChecksum(data, formatEntry.sha256)) {
               spinner.fail(`Checksum mismatch for ${plugin.name} (${format})`);
               error(
                 "The download does not match the expected checksum. This could indicate a corrupted or tampered file.",

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -85,7 +85,7 @@ function registerUpgrade(program: Command): void {
             try {
               const data = await downloadFile(formatEntry.url);
 
-              if (!verifyChecksum(data, formatEntry.sha256)) {
+              if (formatEntry.sha256 && !verifyChecksum(data, formatEntry.sha256)) {
                 spinner.fail(
                   `Checksum mismatch for ${plugin.name} (${format})`,
                 );

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
 import { printBanner } from "./lib/banner.js";
 import { checkForUpdate, loadVersionCache } from "./lib/version.js";
 
-const VERSION = "0.2.0";
+const VERSION = "0.2.1";
 
 // Skip update banner for --version and --help
 const args = process.argv.slice(2);

--- a/apps/cli/src/tests/e2e/registry-schema.e2e.test.ts
+++ b/apps/cli/src/tests/e2e/registry-schema.e2e.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { RegistrySchema } from "@titrate/registry-schema/schema";
+import { REGISTRY_URL } from "../../constants.js";
+
+// Validates that the live remote registry parses against the current Zod schema.
+// Catches schema-vs-registry mismatches before publishing a new binary.
+describe("e2e: remote registry schema validation", () => {
+  it("fetches and parses the live registry without Zod errors", async () => {
+    const response = await fetch(REGISTRY_URL);
+    expect(response.ok).toBe(true);
+
+    const data = await response.json();
+    const registry = RegistrySchema.parse(data);
+
+    expect(registry.plugins.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("contains the known plugin 'ott'", async () => {
+    const response = await fetch(REGISTRY_URL);
+    const data = await response.json();
+    const registry = RegistrySchema.parse(data);
+
+    const ott = registry.plugins.find((p) => p.id === "ott");
+    expect(ott).toBeDefined();
+    expect(ott!.name).toBe("OTT");
+  });
+});

--- a/packages/registry-schema/src/schema.test.ts
+++ b/packages/registry-schema/src/schema.test.ts
@@ -31,6 +31,15 @@ describe("FormatEntrySchema", () => {
     ).toThrow();
   });
 
+  it("accepts an empty sha256 for entries without a computed checksum", () => {
+    const result = FormatEntrySchema.parse({
+      url: "https://example.com/plugin.zip",
+      sha256: "",
+      artifact: "Plugin.vst3",
+    });
+    expect(result.sha256).toBe("");
+  });
+
   it("rejects a sha256 that is too short", () => {
     expect(() =>
       FormatEntrySchema.parse({

--- a/packages/registry-schema/src/schema.ts
+++ b/packages/registry-schema/src/schema.ts
@@ -6,7 +6,7 @@ const PLATFORMS = ["mac", "win", "linux"] as const;
 // A single downloadable file for one format on one platform
 const FormatEntrySchema = z.object({
   url: z.string().url(),
-  sha256: z.string().min(64).max(64),
+  sha256: z.union([z.string().length(64), z.literal("")]),
   artifact: z.string(),
 });
 


### PR DESCRIPTION
## Summary

- Allow empty `sha256` in the registry schema for entries where the checksum has not been computed yet (e.g. `valhalla-supermassive` Windows build). The schema now accepts either a 64-char hex string or an empty string.
- Skip checksum verification in `install` and `upgrade` commands when `sha256` is empty instead of failing with a guaranteed mismatch.
- Add an e2e test that fetches the live remote registry from GitHub and parses it against the Zod schema. This catches schema-vs-registry mismatches before publishing a new binary.
- Bump CLI version to 0.2.1.

Fixes #4

## Test plan

- [ ] `pnpm -r test` passes all 75 tests (including the new remote registry e2e)
- [ ] `pnpm -r type-check` passes
- [ ] `pnpm -r lint` passes
- [ ] Build the CLI (`pnpm --filter @titrate/plug build`) and verify `plug --version` reports 0.2.1
- [ ] Run `plug search ott` to confirm the live registry fetches and parses correctly